### PR TITLE
Use objectclass 'ldapsubentry' to detect repl conflicts

### DIFF
--- a/checkipaconsistency/freeipaserver.py
+++ b/checkipaconsistency/freeipaserver.py
@@ -327,6 +327,7 @@ class FreeIPAServer(object):
         self._log.debug('Checking for LDAP conflicts...')
         results = self._search(
             self._base_dn,
+            '(objectClass=ldapsubentry)',
             '(nsds5ReplConflict=*)',
             ['nsds5ReplConflict']
         )


### PR DESCRIPTION
Recent versions of 389-ds-base make replication conflicts transparent to
clients and add the objectclass 'ldapsubentry' to replication conflict
entries. Clients need to explicitly add this objectclass in searches to find
related objects.

Fixes https://github.com/peterpakos/checkipaconsistency/issues/56

@peterpakos
