### PR TITLE
Fix for issue 56. 

### DIFF
--- a/checkipaconsistency/freeipaserver.py
+++ b/checkipaconsistency/freeipaserver.py
@@ -327,7 +327,7 @@ class FreeIPAServer(object):
         self._log.debug('Checking for LDAP conflicts...')
         results = self._search(
             self._base_dn,
-            '(nsds5ReplConflict=*)',
+            '(|(nsds5ReplConflict=*)(&(objectclass=ldapsubentry)(nsds5ReplConflict=*)))',
             ['nsds5ReplConflict']
         )
 


### PR DESCRIPTION
Fixes # 56: 
replication conflicts are not detected in recent version of FreeIPA #56

Changes proposed in this pull request:

- the conflict filter should depend on 389-ds-base version.
- get the 389-ds-base querying the vendorVersion from the NULL base dn
 

@peterpakos
