### PR TITLE
 Fix issue #60: set the logger at FreeIPAServer object level

### DIFF
--- a/checkipaconsistency/freeipaserver.py
+++ b/checkipaconsistency/freeipaserver.py
@@ -29,8 +29,8 @@ import dns.resolver
 
 
 class FreeIPAServer(object):
-    def __init__(self, host, domain, binddn, bindpw):
-        self._log = logging.getLogger()
+    def __init__(self, host, domain, binddn, bindpw, logger):
+        self._log = logger
         self._log.debug('Initialising FreeIPA server %s' % host)
 
         self.users = None

--- a/checkipaconsistency/main.py
+++ b/checkipaconsistency/main.py
@@ -117,7 +117,7 @@ class Main(object):
 
         self._servers = OrderedDict()
         for host in self._hosts:
-            self._servers[host] = FreeIPAServer(host, self._domain, self._binddn, self._bindpw)
+            self._servers[host] = FreeIPAServer(host, self._domain, self._binddn, self._bindpw, self._log)
 
         self._checks = OrderedDict([
             ('users', 'Active Users'),


### PR DESCRIPTION
Fixes # .

Changes proposed in this pull request:
- assigning the logger to the FreeIpa object, so as to keep the settings we have given in main.

@peterpakos
