### PR TITLE
Fix for #62: RFE : remove py33 from tox.ini and travis.yml 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ matrix:
   include:
   - python: "2.7"
     env: TOXENV=py27
-  - python: "3.3"
-    env: TOXENV=py33
   - python: "3.4"
     env: TOXENV=py34
   - python: "3.5"

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 2.3.1
-envlist = py27,py33,py34,py35,py36,pep8py2,pep8py3,packagepy2,packagepy3
+envlist = py27,py34,py35,py36,pep8py2,pep8py3,packagepy2,packagepy3
 skip_missing_interpreters = true
 
 [testenv]


### PR DESCRIPTION
Fixes # 62

Changes proposed in this pull request:
- remove py33 from tox.ini and .travis.yml
- 
- 

@peterpakos
